### PR TITLE
Bugfix: Fixed circular dependency

### DIFF
--- a/lib/omniauth-goodreads/version.rb
+++ b/lib/omniauth-goodreads/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Goodreads
-    VERSION = "0.1.0"
+    VERSION = "1.0.0"
   end
 end

--- a/omniauth-goodreads.gemspec
+++ b/omniauth-goodreads.gemspec
@@ -35,18 +35,15 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      # s.add_runtime_dependency(%q<omniauth-goodreads>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
       s.add_runtime_dependency(%q<omniauth-oauth>, ["~> 1.1"])
       s.add_runtime_dependency(%q<multi_xml>, ["~> 0.5.5"])
     else
-      # s.add_dependency(%q<omniauth-goodreads>, [">= 0"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
       s.add_dependency(%q<omniauth-oauth>, ["~> 1.1"])
       s.add_dependency(%q<multi_xml>, ["~> 0.5.5"])
     end
   else
-    # s.add_dependency(%q<omniauth-goodreads>, [">= 0"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
     s.add_dependency(%q<omniauth-oauth>, ["~> 1.1"])
     s.add_dependency(%q<multi_xml>, ["~> 0.5.5"])

--- a/omniauth-goodreads.gemspec
+++ b/omniauth-goodreads.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "omniauth-goodreads"
-  s.version = "0.2.0"
+  s.version = "1.0.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ahmed El.Hussaini"]
-  s.date = "2014-02-10"
+  s.date = "2016-02-15"
   s.description = "OmniAuth strategy for Goodreads"
   s.email = "aelhussaini@gmail.com"
   s.extra_rdoc_files = [
@@ -35,20 +35,20 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<omniauth-goodreads>, [">= 0"])
+      # s.add_runtime_dependency(%q<omniauth-goodreads>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
-      s.add_runtime_dependency(%q<omniauth-oauth>, ["~> 1.0.1"])
+      s.add_runtime_dependency(%q<omniauth-oauth>, ["~> 1.1"])
       s.add_runtime_dependency(%q<multi_xml>, ["~> 0.5.5"])
     else
-      s.add_dependency(%q<omniauth-goodreads>, [">= 0"])
+      # s.add_dependency(%q<omniauth-goodreads>, [">= 0"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
-      s.add_dependency(%q<omniauth-oauth>, ["~> 1.0.1"])
+      s.add_dependency(%q<omniauth-oauth>, ["~> 1.1"])
       s.add_dependency(%q<multi_xml>, ["~> 0.5.5"])
     end
   else
-    s.add_dependency(%q<omniauth-goodreads>, [">= 0"])
+    # s.add_dependency(%q<omniauth-goodreads>, [">= 0"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
-    s.add_dependency(%q<omniauth-oauth>, ["~> 1.0.1"])
+    s.add_dependency(%q<omniauth-oauth>, ["~> 1.1"])
     s.add_dependency(%q<multi_xml>, ["~> 0.5.5"])
   end
 end


### PR DESCRIPTION
When attempted to use this gem, the following error message is returned from Bundler:

```
Your bundle requires gems that depend on each other, creating an infinite loop. Please remove gem 'omniauth-goodreads' and try again.
```

This is from omniauth-goodreads requiring itself.