### PR TITLE
bug fix - changed http to https

### DIFF
--- a/lib/omniauth/strategies/goodreads.rb
+++ b/lib/omniauth/strategies/goodreads.rb
@@ -6,9 +6,9 @@ module OmniAuth
   module Strategies
     class Goodreads < OmniAuth::Strategies::OAuth
       option :client_options, {
-        :site => 'http://www.goodreads.com',
-        :authorize_url => 'http://www.goodreads.com/oauth/authorize',
-        :token_url => 'http://www.goodreads.com/oauth/access_token'
+        :site => 'https://www.goodreads.com',
+        :authorize_url => 'https://www.goodreads.com/oauth/authorize',
+        :token_url => 'https://www.goodreads.com/oauth/access_token'
       }
 
       def request_phase


### PR DESCRIPTION
I was encountering a 301 error using the gem as per your master, so I found some `http`s that should be `https`s and that cleared things up locally. Cheers!